### PR TITLE
Android 14 QPR2 fix + bump version to 4.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        version_name = '4.3.1'
+        version_name = '4.3.2'
     }
 }
 

--- a/compat/src/main/java/rikka/hidden/compat/PermissionManagerApis.java
+++ b/compat/src/main/java/rikka/hidden/compat/PermissionManagerApis.java
@@ -26,8 +26,17 @@ public class PermissionManagerApis {
         }
     }
 
-    public static void grantRuntimePermission(@Nullable String packageName, @Nullable String permissionName, int userId) throws RemoteException {
-        if (Build.VERSION.SDK_INT >= 30) {
+    public static void grantRuntimePermission(@Nullable String packageName, @Nullable String permissionName, int deviceId, int userId) throws RemoteException {
+        if (Build.VERSION.SDK_INT >= 34) {
+            IPermissionManager perm = permissionManager.get();
+            Objects.requireNonNull(perm);
+
+            try {
+                perm.grantRuntimePermission(packageName, permissionName, deviceId, userId);
+            }catch (NoSuchMethodError e) {
+                perm.grantRuntimePermission(packageName, permissionName, userId);
+            }
+        } else if (Build.VERSION.SDK_INT >= 30) {
             IPermissionManager perm = permissionManager.get();
             Objects.requireNonNull(perm);
             perm.grantRuntimePermission(packageName, permissionName, userId);
@@ -38,8 +47,17 @@ public class PermissionManagerApis {
         }
     }
 
-    public static void revokeRuntimePermission(@Nullable String packageName, @Nullable String permissionName, int userId) throws RemoteException {
-        if (Build.VERSION.SDK_INT >= 30) {
+    public static void revokeRuntimePermission(@Nullable String packageName, @Nullable String permissionName, int deviceId, int userId) throws RemoteException {
+        if (Build.VERSION.SDK_INT >= 34) {
+            IPermissionManager perm = permissionManager.get();
+            Objects.requireNonNull(perm);
+
+            try {
+                perm.revokeRuntimePermission(packageName, permissionName, deviceId, userId, (String) null);
+            } catch (NoSuchMethodError e) {
+                perm.revokeRuntimePermission(packageName, permissionName, userId, (String) null);
+            }
+        } else if (Build.VERSION.SDK_INT >= 30) {
             IPermissionManager perm = permissionManager.get();
             Objects.requireNonNull(perm);
 

--- a/stub/src/main/java/android/permission/IPermissionManager.java
+++ b/stub/src/main/java/android/permission/IPermissionManager.java
@@ -15,10 +15,16 @@ public interface IPermissionManager extends IInterface {
     void grantRuntimePermission(String packageName, String permissionName, int userId)
             throws RemoteException;
 
+    void grantRuntimePermission(String packageName, String permissionName, int deviceId, int userId)
+            throws RemoteException;
+
     void revokeRuntimePermission(String packageName, String permissionName, int userId)
             throws RemoteException;
 
     void revokeRuntimePermission(String packageName, String permissionName, int userId, String reason)
+            throws RemoteException;
+
+    void revokeRuntimePermission(String packageName, String permissionName, int deviceId, int userId, String reason)
             throws RemoteException;
 
     int getPermissionFlags(String permissionName, String packageName, int userId)


### PR DESCRIPTION
This PR adds support for `grantRuntimePermission` and `revokeRuntimePermission`'s new signatures on Android 14 QPR2. Once merged & built, this can be used to fix https://github.com/RikkaApps/Shizuku/issues/373 (I have another PR ready for that too)