### PR TITLE
Add `INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK` to PackageManagerHidden

### DIFF
--- a/stub/src/main/java/android/content/pm/PackageManagerHidden.java
+++ b/stub/src/main/java/android/content/pm/PackageManagerHidden.java
@@ -2,6 +2,8 @@ package android.content.pm;
 
 import java.util.List;
 
+import androidx.annotation.RequiresApi;
+
 import dev.rikka.tools.refine.RefineAs;
 
 @RefineAs(PackageManager.class)
@@ -10,6 +12,9 @@ public class PackageManagerHidden {
     public static int MATCH_UNINSTALLED_PACKAGES;
     public static int INSTALL_REPLACE_EXISTING;
     public static int INSTALL_ALLOW_TEST;
+
+    @RequiresApi(34)
+    public static int INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK;
 
     public ApplicationInfo getApplicationInfoAsUser(String packageName, int flags, int userId) throws PackageManager.NameNotFoundException {
         throw new RuntimeException();


### PR DESCRIPTION
[Starting from Android 14, apps that target SDK versions too old are blocked from being installed.](https://developer.android.com/about/versions/14/behavior-changes-all#minimum-target-api-level) Root and shell are allowed to bypass this limitation if [`INSTALL_BYPASS_LOW_TARGET_SDK_BLOCK` flag](https://android.googlesource.com/platform/frameworks/base/+/7c710f62228fbc829eaa097204a00bccd8aa420d%5E%21/#F0) is used.